### PR TITLE
Very small patch: added rights check

### DIFF
--- a/ArchSetup
+++ b/ArchSetup
@@ -17,6 +17,7 @@
 # along with ArchSetup.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 from SetupTools.SetupConfig import SetupConfig
 from Interface.Interface import Interface
 from Interface.WelcomeWindow import WelcomeWindow
@@ -51,4 +52,8 @@ class ArchSetup:
             self.interface.addwin(self.windows[self.window_index])
 
 if __name__ == "__main__":
-	ArchSetup()
+  if os.getuid() != 0:
+    print("You need to be root to run ArchSetup")
+    quit()
+  else:
+    ArchSetup()


### PR DESCRIPTION
If the user who runs the Setup has not the UID 0 (root or with sudo), the Setup will exit with an error, so it will not fail later after the user has might made a lot of selections...
